### PR TITLE
Update deploy-zksync.sh

### DIFF
--- a/deploy-zksync.sh
+++ b/deploy-zksync.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function bashcolor {
-    if [ $2 ]; then
+    if [ "$2" ]; then
         echo -e "\e[$1;$2m"
     else
         echo -e "\e[$1m"
@@ -23,14 +23,14 @@ if [[ "$1" != "--skipCompile" ]]; then
     echo "  "
 
     if [ -d "./artifacts-zk" ]; then
-        rm -rf ./artifacts-zk
+        rm -rf "./artifacts-zk"
     fi
     if [ -d "./cache-zk" ]; then
-        rm -rf ./cache-zk
+        rm -rf "./cache-zk"
     fi
 
     yarn hardhat compile --network zkTestnet
-  else
+else
     skippedCompile=1
     echo "  "
     echo "  //////////////////////////////////////////////////"
@@ -58,10 +58,10 @@ echo "  //////////////////////////////////////////////////"
 
 script=""
 if [[ "$skippedCompile" == 0 && "$1" ]]; then
-    script=$1
-  else
+    script="$1"
+else
     if [[ "$skippedCompile" == 1 && "$2" ]]; then
-      script=$2
+        script="$2"
     fi
 fi
 
@@ -69,7 +69,7 @@ if [[ ! -z "$script" ]]; then
     echo "  Use deploy script: $script"
     echo "  "
     yarn hardhat deploy-zksync --script "$script".ts --network zkTestnet
-  else
+else
     echo "  Use all deploy scripts."
     echo "  "
     yarn hardhat deploy-zksync --network zkTestnet


### PR DESCRIPTION
Some minor fixes....

 -I added quotes in conditions like "$2", this is
 It prevents us from getting an error when the variable content is empty.
 - I added quotes in commands like rm -rf"./artifacts-zk" and rm -rf "./cache-zk", this prevents us from getting errors if the file or directory name contains spaces.
 - if [[ "$skipped Compile" == 0 && "$1" ]];  then and if [[ "$skipped Compile" == 1 && "$2" ]];  I added spaces in if conditions like then and quoted $1 and $2, which prevents us from getting an error if the variables are empty.
 - I added quotes in expressions such as script="$1" and script="$2" to assign a value to the script variable.
 - For checking a non-null variable [[!  I added quotes using -z "$script"]].

 I thought these changes would make the code run more reliably and consistently. If I make a mistake, please let me know.